### PR TITLE
Add disable dark reader meta tag

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -47,6 +47,7 @@ const seo: SEOProps = {
     <meta name = "viewport" content = "width=device-width"/>
     <link rel = "icon" type = "image/svg+xml" href = "/favicon.svg"/>
     <meta name = "generator" content = {Astro.generator}/>
+    <meta name = "darkreader-lock">
     <title>{title}</title>
     <link rel = "preconnect" href = "https://fonts.googleapis.com">
     <link rel = "preconnect" href = "https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
While Dark Reader's automatic detection does a pretty good job at picking up Modtober fest as being a dark site, every now and then it just doesn't work, causing me to get flash-banged and making the the site unusable till I reload. This fixes that by using the method documented here: https://github.com/darkreader/darkreader/blob/main/CONTRIBUTING.md#disabling-dark-reader-on-your-site to disable dark reader without it having to detect the theme.

I have not tested it, but this seems like the correct place to put additional meta tags.