### PR TITLE
Fix grammar in faq.astro

### DIFF
--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -77,8 +77,8 @@ import Item from "../components/ui/Item.astro";
 
             <Item title = "How will the prizes be shipped?">
                 The prizes will be shipped through Canada Post. International shipping is supported in most countries. Please keep in mind
-                that you may be expected to pay customs, duties, or taxes depending on where you live. Tracking codes will not be available
-                replacements are not guaranteed due to the limited quantities of stickers available.
+                that you may be expected to pay customs, duties, or taxes depending on where you live. Tracking codes will not be available.
+                Replacements are not guaranteed due to the limited quantities of stickers available.
             </Item>
 
     </div>


### PR DESCRIPTION
Was reading the FAQ, found a grammar issue and fixed it, as far as I can tell (as in, original meaning preserved).
Yes, I am aware this won't contribute to my pull request count.