### PR TITLE
Update stored GitHub user info on login

### DIFF
--- a/src/pages/auth/github/callback.ts
+++ b/src/pages/auth/github/callback.ts
@@ -37,6 +37,11 @@ export async function GET(context: APIContext): Promise<Response> {
                     id: existingUser.id
                 },
                 data: {
+                    github_id: githubUser.id,
+                    username: githubUser.login,
+                    name: githubUser.name || "NA",
+                    avatar: githubUser.avatar_url,
+                    email: githubUser.email || "NA",
                     access_token: tokens.accessToken,
                 }
             })


### PR DESCRIPTION
This PR fixes #20 by amending the GitHub auth callback to update the stored user information from the user information provided by GitHub on login. The added lines mirror the lines used when creating the user from scratch, except the `id` line (which doesn't need to be updated), the `github_id` line (which will never change for a given user), and the `admin` line (since that's a manual field).