### PR TITLE
feat(admin): add statistics page to admin panel

### DIFF
--- a/src/components/ui/ContributorTable.astro
+++ b/src/components/ui/ContributorTable.astro
@@ -1,0 +1,32 @@
+---
+interface Props {
+    contributors: any[];
+}
+
+const { contributors } = Astro.props;
+---
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    {contributors.map((contributor, index) => {
+        const iconColor = index === 0 ? 'text-yellow-500' : index === 1 ? 'text-gray-400' : 'text-yellow-700';
+        return (
+                <div class="flex items-center p-4 rounded-lg shadow-md bg-[#27323b]">
+                    <div class="relative mr-4">
+                        <img src={`https://github.com/${contributor.author}.png`} alt={contributor.author} class="w-16 h-16 rounded-full"/>
+                        {index < 3 && (
+                                <div class="absolute -top-2 -right-2 w-6 h-6">
+                                    <svg class={`w-6 h-6 ${iconColor}`} fill="currentColor" viewBox="0 0 20 20">
+                                        <path d="M9.049 2a1 1 0 011.902 0l.7 2.152a1 1 0 00.95.69h2.264a1 1 0 01.592 1.806l-1.83 1.364a1 1 0 00-.364 1.118l.7 2.152a1 1 0 01-1.54 1.118L10 10.727l-1.82 1.355a1 1 0 01-1.54-1.118l.7-2.152a1 1 0 00-.364-1.118L5.146 6.648a1 1 0 01.592-1.806h2.264a1 1 0 00.95-.69L9.049 2z"/>
+                                    </svg>
+                                </div>
+                        )}
+                    </div>
+                    <div>
+                        <a href={`https://github.com/${contributor.author}`} target="_blank" rel="noopener noreferrer" class="text-xl font-semibold text-blue-600 hover:underline">
+                            {contributor.author}
+                        </a>
+                        <p class="text-gray-600">PRs Submitted: {contributor._count.author}</p>
+                    </div>
+                </div>
+        );
+    })}
+</div>

--- a/src/components/ui/StatsCard.astro
+++ b/src/components/ui/StatsCard.astro
@@ -1,0 +1,20 @@
+---
+import {Icon} from "astro-icon/components";
+interface Props {
+    title: string;
+    value: number;
+    icon: string;
+    color: string;
+}
+
+const { title, value, icon, color } = Astro.props;
+---
+<div class={`flex items-center p-4 rounded-lg shadow-md text-white ${color}`}>
+    <div class="mr-4">
+        <Icon name=`${icon}` class="w-12 h-12 fill-current"/>
+    </div>
+    <div>
+        <h3 class="text-xl font-semibold">{title}</h3>
+        <p class="text-3xl font-bold">{value}</p>
+    </div>
+</div>

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -42,6 +42,9 @@ if (!isUserAdmin(user)) {
             <AdminCard name = "Rewards" path = "/admin/rewards">
                 <Icon name = "octicon:trophy-16" class = "my-auto w-full h-full"/>
             </AdminCard>
+            <AdminCard name = "Stats" path = "/admin/stats">
+                <Icon name = "octicon:graph-16" class = "my-auto w-full h-full"/>
+            </AdminCard>
         </div>
     </div>
 </Layout>

--- a/src/pages/admin/stats.astro
+++ b/src/pages/admin/stats.astro
@@ -1,0 +1,84 @@
+---
+import Layout from '@layouts/Layout.astro';
+import StatsCard from '@components/ui/StatsCard.astro';
+import prisma from '@lib/db';
+import { isUserAdmin } from '@lib/util';
+import ContributorTable from '@components/ui/ContributorTable.astro';
+import PageTitle from "../../components/ui/PageTitle.astro";
+
+const user = Astro.locals.user;
+if (!isUserAdmin(user)) {
+    return Astro.redirect('/403?url=/admin/stats');
+}
+
+const [totalPRs, approvedPRs, rejectedPRs, pendingPRs, topContributors, totalRepositories] = await Promise.all([
+    prisma.pullRequest.count(),
+    prisma.pullRequestStatus.count({
+        where: {
+            reviewed: true,
+            invalid: false,
+        },
+    }),
+    prisma.pullRequestStatus.count({
+        where: {
+            reviewed: true,
+            invalid: true,
+        },
+    }),
+    prisma.pullRequestStatus.count({
+        where: {
+            reviewed: false,
+        },
+    }),
+    prisma.pullRequest.groupBy({
+        by: ['author'],
+        _count: {
+            author: true,
+        },
+        orderBy: {
+            _count: {
+                author: 'desc',
+            },
+        },
+        take: 10,
+    }),
+    prisma.repository.count(),
+]);
+
+const totalReviewedPRs = approvedPRs + rejectedPRs;
+const approvedPercentage = totalReviewedPRs > 0 ? (approvedPRs / totalReviewedPRs) * 100 : 0;
+const rejectedPercentage = totalReviewedPRs > 0 ? (rejectedPRs / totalReviewedPRs) * 100 : 0;
+const pendingPercentage = totalPRs > 0 ? (pendingPRs / totalPRs) * 100 : 0;
+---
+<Layout title="Statistics" description="Overview of statistics for the Modtoberfest event." canonical="/admin/stats">
+    <PageTitle>Statistics</PageTitle>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <StatsCard title="Total PRs" value={totalPRs} icon="octicon:git-pull-request-24" color="bg-blue-500" />
+        <StatsCard title="Approved PRs" value={approvedPRs} icon="octicon:check-circle-24" color="bg-green-500" />
+        <StatsCard title="Rejected PRs" value={rejectedPRs} icon="octicon:x-24" color="bg-red-500" />
+        <StatsCard title="Pending PRs" value={pendingPRs} icon="octicon:clock-24" color="bg-yellow-500" />
+        <StatsCard title="Total Repositories" value={totalRepositories} icon="octicon:repo-24" color="bg-purple-500" />
+    </div>
+
+    <div class="mt-12">
+
+    <h2 class="text-white text-3xl font-semibold border-b-2 tracking-wide mb-4 pb-4 font-brand">PR Review Progress</h2>
+        <div class="w-full bg-gray-200 rounded-full h-6 overflow-hidden flex">
+            <div class="bg-green-500 h-6" style={`width: ${approvedPercentage}%`}></div>
+            <div class="bg-red-500 h-6" style={`width: ${rejectedPercentage}%`}></div>
+            <div class="bg-yellow-500 h-6" style={`width: ${pendingPercentage}%`}></div>
+        </div>
+        <div class="flex justify-between text-sm mt-2">
+            <span>Approved: {approvedPercentage.toFixed(1)}%</span>
+            <span>Rejected: {rejectedPercentage.toFixed(1)}%</span>
+            <span>Pending: {pendingPercentage.toFixed(1)}%</span>
+        </div>
+    </div>
+
+    <div class="mt-12">
+        <h2 class="text-white text-3xl font-semibold border-b-2 tracking-wide mb-4 pb-4 font-brand">Top Contributors</h2>
+        <ContributorTable contributors={topContributors} />
+    </div>
+
+</Layout>


### PR DESCRIPTION
Implemented a new statistics page in the admin panel that displays general statistics, top contributors, and PR review progress. The page includes:

- Stats cards with total PRs, approved, rejected, pending PRs, and total repositories.
- Progress bar showing PR review status.
- Contributor cards highlighting the top contributors, with "medals" for the top three.
![CleanShot 2024-10-26 at 18 35 00@2x](https://github.com/user-attachments/assets/5074c21f-80f6-4bee-8d0b-15b44bc41f41)
