### PR TITLE
feat: create custom 404 error page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,12 @@
+---
+import Layout from '@layouts/Layout.astro';
+
+const attemptedUrl = new URL(Astro.request.url).pathname;
+---
+<Layout title="404 - Page Not Found" description="The page you're looking for doesn't exist." canonical="/404">
+    <div class="container mx-auto flex flex-col items-center justify-center text-center px-4">
+        <h1 class="text-5xl font-bold mt-12 text-white">404 - Page Not Found</h1>
+        <p class="text-lg mt-4 text-gray-300">The page ('{attemptedUrl}') you're trying to access doesn't exist. Please check the URL and try again.</p>
+        <a href="/" class="text-brand-600 hover:underline text-base mt-6">Return to Home</a>
+    </div>
+</Layout>


### PR DESCRIPTION
Adding a custom 404 error page, keeping the same style as the 403 page (as suggested in PR #30. Now it only shows the path part of the attempted URL.
