### PR TITLE
Represent number of issues as 0 when issues are disabled

### DIFF
--- a/src/actions/repository.ts
+++ b/src/actions/repository.ts
@@ -64,7 +64,7 @@ export const repository = {
                             url: data.html_url,
                             description: data.description,
                             stars: data.stargazers_count,
-                            openIssues: data.open_issues_count,
+                            openIssues: repoData.has_issues ? repoData.open_issues_count : 0,
                             language: data.language ? {
                                 connect: {
                                     name: data.language ?? ""

--- a/src/actions/repository.ts
+++ b/src/actions/repository.ts
@@ -64,7 +64,7 @@ export const repository = {
                             url: data.html_url,
                             description: data.description,
                             stars: data.stargazers_count,
-                            openIssues: repoData.has_issues ? repoData.open_issues_count : 0,
+                            openIssues: data.has_issues ? data.open_issues_count : 0,
                             language: data.language ? {
                                 connect: {
                                     name: data.language ?? ""

--- a/src/pages/admin/repositories/index.astro
+++ b/src/pages/admin/repositories/index.astro
@@ -92,7 +92,7 @@ const repos = await Promise.all(dbRepos.map<Promise<AdminRepository>>(async repo
             url: repoData.html_url,
             description: repoData.description,
             stars: repoData.stargazers_count,
-            openIssues: repoData.open_issues_count,
+            openIssues: repoData.has_issues ? repoData.open_issues_count : 0,
             repository_id: repo.repository_id,
             id: repo.id,
             // Language requires more database lookups, it will be inserted when repos are updated later

--- a/src/pages/admin/repositories/submitted.astro
+++ b/src/pages/admin/repositories/submitted.astro
@@ -62,7 +62,7 @@ const repos = await Promise.all(dbRepos.map(async repo => {
             url: repoData.html_url,
             description: repoData.description,
             stars: repoData.stargazers_count,
-            openIssues: repoData.open_issues_count,
+            openIssues: repoData.has_issues ? repoData.open_issues_count : 0,
             repository_id: repo.repository_id,
             id: repo.id,
             updatedAt: new Date(repoData.pushed_at!),

--- a/src/pages/admin/repositories/tag.astro
+++ b/src/pages/admin/repositories/tag.astro
@@ -50,7 +50,7 @@ const repos = await Promise.all(dbRepos.map(async repo => {
             url: repoData.html_url,
             description: repoData.description,
             stars: repoData.stargazers_count,
-            openIssues: repoData.open_issues_count,
+            openIssues: repoData.has_issues ? repoData.open_issues_count : 0,
             repository_id: repo.repository_id,
             id: repo.id,
             updatedAt: new Date(repoData.pushed_at!),

--- a/src/pages/api/admin/repositories/bulk.ts
+++ b/src/pages/api/admin/repositories/bulk.ts
@@ -51,7 +51,7 @@ export async function POST({request}: APIContext) {
                             url: repoData.html_url,
                             description: repoData.description,
                             stars: repoData.stargazers_count,
-                            openIssues: repoData.open_issues_count,
+                            openIssues: repoData.has_issues ? repoData.open_issues_count : 0,
                             language: repoData.language ? {
                                 connect: {
                                     name: repoData.language ?? ""
@@ -78,7 +78,7 @@ export async function POST({request}: APIContext) {
                                 url: repoData.html_url,
                                 description: repoData.description,
                                 stars: repoData.stargazers_count,
-                                openIssues: repoData.open_issues_count,
+                                openIssues: repoData.has_issues ? repoData.open_issues_count : 0,
                                 updatedAt: repoData.pushed_at as string,
                                 license: repoData.license ? repoData.license.name : undefined,
                                 language: repoData.language ? {
@@ -95,7 +95,7 @@ export async function POST({request}: APIContext) {
                                 url: repoData.html_url,
                                 description: repoData.description,
                                 stars: repoData.stargazers_count,
-                                openIssues: repoData.open_issues_count,
+                                openIssues: repoData.has_issues ? repoData.open_issues_count : 0,
                                 updatedAt: repoData.pushed_at as string,
                                 language: repoData.language ? {
                                     connect: {

--- a/src/pages/api/admin/repositories/update.ts
+++ b/src/pages/api/admin/repositories/update.ts
@@ -83,7 +83,7 @@ export async function POST({request}: APIContext) {
                             url: repoData.html_url,
                             description: repoData.description,
                             stars: repoData.stargazers_count,
-                            openIssues: repoData.open_issues_count,
+                            openIssues: repoData.has_issues ? repoData.open_issues_count : 0,
                             updatedAt: repoData.pushed_at as string,
                             license: repoData.license ? repoData.license.name : undefined,
                             language: repoData.language ? {
@@ -100,7 +100,7 @@ export async function POST({request}: APIContext) {
                             url: repoData.html_url,
                             description: repoData.description,
                             stars: repoData.stargazers_count,
-                            openIssues: repoData.open_issues_count,
+                            openIssues: repoData.has_issues ? repoData.open_issues_count : 0,
                             updatedAt: repoData.pushed_at as string,
                             language: repoData.language ? {
                                 connect: {

--- a/src/pages/repositories/submit.astro
+++ b/src/pages/repositories/submit.astro
@@ -89,7 +89,7 @@ const allRepos = (await octokit.paginate("GET /user/repos", {
             url: repo.html_url,
             description: repo.description,
             stars: repo.stargazers_count,
-            openIssues: repo.open_issues_count,
+            openIssues: repo.has_issues ? repo.open_issues_count : 0,
             updatedAt: repo.pushed_at ? new Date(repo.pushed_at).getTime() : 0,
             language: languages[repo.language ?? ""],
             license: (repo.license ?? {name: null}).name,


### PR DESCRIPTION
When issues are disabled on a repo, the only issues are actually pull requests and therefore shouldn't be counted