### PR TITLE
Add back the `givemethepower` admin endpoint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ After creating the OAuth app, you should have the _app client ID_ and _app clien
 3. Copy the `.env.example` file into an `.env` file. (The copied file is git-ignored.)
 4. In the newly-copied `.env` file:
     - Put the app client ID after the `GITHUB_ID=` line.
-    - Put the app client secret after the `GITHUB_SECRET=line`.
+    - Put the app client secret after the `GITHUB_SECRET=` line.
     - Put your own randomly-generated secret after the `ADMIN_SECRET=` line.
 5. Bring up the database through Docker:
    ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ After creating the OAuth app, you should have the _app client ID_ and _app clien
 4. In the newly-copied `.env` file:
     - Put the app client ID after the `GITHUB_ID=` line.
     - Put the app client secret after the `GITHUB_SECRET=line`.
+    - Put your own randomly-generated secret after the `ADMIN_SECRET=` line.
 5. Bring up the database through Docker:
    ```bash
    docker compose -f docker-compose-dev.yml up db
@@ -61,3 +62,32 @@ To bring the site down gracefully:
    docker compose -f docker-compose-dev.yml down db
    ```
 2. Terminate the `npm run dev` command using the `CTRL + C` keyboard shortcut.
+
+### Admin
+
+To gain access to the administrator panel, you can POST to the `/auth/admin/givemethepower` API endpoint.
+
+The endpoint accepts a JSON object with `secret` and `github_id` fields. Fill the `secret` field with the value of
+`ADMIN_SECRET` (from your `.env` file) and the `github_id` field with your GitHub user ID.
+
+Your GitHub user ID can be found by visiting `https://api.github.com/users/<username>`, replacing `<username>` with
+your GitHub username, and checking the `id` field in the resulting JSON response.
+
+The following invocations are provided for convenience. Remember to replace the `<ADMIN_SECRET>` and 
+`<GITHUB_USER_ID>` placeholders.
+
+- For Linux `bash`:
+   ```bash
+   curl \
+     -H "Content-Type: application/json" \
+     -d '{"secret":"<ADMIN_SECRET>","github_id":"<GITHUB_USER_ID>"}' \
+     http://localhost:4321/api/admin/givemethepower
+   ```
+- For Windows PowerShell:
+   ```pwsh
+   Invoke-RestMethod `
+     -Method 'Post' `
+     -ContentType "application/json" `
+     -Body '{"secret":"<ADMIN_SECRET>","github_id":"<GITHUB_USER_ID>"}' `
+     -Uri http://localhost:4321/api/admin/givemethepower
+   ```

--- a/src/pages/api/admin/givemethepower.ts
+++ b/src/pages/api/admin/givemethepower.ts
@@ -1,0 +1,24 @@
+import type {APIContext} from "astro";
+import prisma from "../../../lib/db";
+
+export async function POST({request}: APIContext) {
+    const body = await request.json();
+
+    if (import.meta.env.ADMIN_SECRET !== "" && body.secret !== import.meta.env.ADMIN_SECRET) {
+        return new Response(null, {
+            status: 404
+        })
+    }
+
+    await prisma.user.update({
+        data: {
+            admin: true
+        },
+        where: {
+            github_id: Number(body.github_id)
+        }
+    })
+    return new Response("You have the power!", {
+        status: 200
+    })
+}


### PR DESCRIPTION
This PR adds the `/api/admin/givemethepower` endpoint, which allows someone with access to the `ADMIN_SECRET` to promote any user to be an administrator. This is primarily useful in development environments, where administrator access is needed to simulate functionality and manual access to the database may not be feasible to acquire.

This was removed in https://github.com/Mycelium-Mod-Network/Modtoberfest-Site/commit/847895c03b4fb78d276d455c6af868f0ece5fc77#diff-02dc515342bb1a484e24459699d6386b29eb570e785977a0a56a033ca9f18075, and @jaredlll08 himself said that "adding that page back would be an instant accept lol"[^1].

Instructions on how to use this endpoint are provided in the CONTRIBUTING.md file, for developer convenience.

[^1]: See the Mycelium Mod Network Discord server, [message in `#modtoberfest`](https://discord.com/channels/752944675425353768/752993307348697264/1432474602071785482)