### PR TITLE
Use `justify-center` for repositories page

### DIFF
--- a/src/pages/repositories/index.astro
+++ b/src/pages/repositories/index.astro
@@ -142,7 +142,7 @@ const user = Astro.locals.user;
                 </select>
             </div>
         </div>
-        <div class = "flex flex-col sm:flex-row gap-8 flex-wrap mt-6 w-full justify-between">
+        <div class = "flex flex-col sm:flex-row gap-8 flex-wrap mt-6 w-full justify-center">
             {repos.map((repo) =>
                     <>
                         <Repository repo = {repo}/>


### PR DESCRIPTION
This PR adjusts the look of the repositories page for width-constrained viewports by replacing `justify-between` with `justify-center`.

The `justify-between` property can cause large gaps between columns for rows with fewer than 4 columns. `justify-center` instead positions the items towards the page middle, which avoids the large gaps.

| Before | After |
|:------:|:-----:|
| <img width="808" height="748" alt="Large gaps between items, no gap between outermost items and viewport sides" src="https://github.com/user-attachments/assets/be605873-a3c5-4a2b-a987-799b2a98c4e0" /> | <img width="808" height="748" alt="No gaps between items, large gap between outermost items and viewport sides" src="https://github.com/user-attachments/assets/d61a8ec6-2d2f-4e5c-b7ab-8ebca75ff1af" />

It has been suggested to replace the use of CSS flexbox with CSS grid. I would rather leave that to the hands of professionals, but I can make a PR for that if wanted too.


