### PR TITLE
Add sorting to and improve filters on repositories

### DIFF
--- a/src/pages/repositories/index.astro
+++ b/src/pages/repositories/index.astro
@@ -137,7 +137,7 @@ const user = Astro.locals.user;
             <span class = "font-brand">Repositories</span>
 
             {user && <a href = "/repositories/submit" class = "no-underline">
-                <button class = "px-4 border border-primary rounded-md text-lg font-bold shadow-sm bg-primary text-black animate-sm-glow hover:bg-secondary hover:border-secondary transition-colors">Submit</button>
+                <button class = "px-4 border border-primary rounded-md text-lg font-medium shadow-sm bg-primary text-black animate-sm-glow hover:bg-secondary hover:border-secondary transition-colors">Submit</button>
             </a>}
         </h1>
         <div class = "flex flex-col sm:flex-row gap-4">

--- a/src/pages/repositories/index.astro
+++ b/src/pages/repositories/index.astro
@@ -15,10 +15,19 @@ const DATE_FILTERS = [
     {display: "180 Days", id: "180d", date: now.getTime() - MILLISECONDS_PER_DAY * 180},
     {display: "1 Year", id: "1y", date: now.getTime() - MILLISECONDS_PER_DAY * 365},
     {display: "2 Years", id: "2y", date: now.getTime() - MILLISECONDS_PER_DAY * 730}];
+const SORT_FILTERS = [
+    "Random",
+    "Recently Updated",
+    "Most Stars",
+    "Least Stars",
+    "Most Issues",
+    "Least Issues",
+];
 const url = Astro.url;
 
 const selectedDate = url.searchParams.get("updated_within")
 const selectedDateObj = new Date(DATE_FILTERS.find(x => x.id === selectedDate)?.date ?? 0);
+const sortBy = url.searchParams.get("sort_by")
 const selectedTag = url.searchParams.get("tag")
 const tags = (await prisma.tag.findMany({
     select: {
@@ -101,7 +110,17 @@ const dbRepos: DisplayRepository[] = (await prisma.repository.findMany({
     }
     return repos;
 }, [])
-shuffleArray(dbRepos)
+
+dbRepos.sort((a, b) => {
+    if (sortBy == "Most Stars") return a.stars - b.stars
+    else if (sortBy == "Most Stars") return b.stars - a.stars
+    else if (sortBy == "Least Stars") return b.stars - a.stars
+    else if (sortBy == "Most Issues") return a.openIssues - b.openIssues
+    else if (sortBy == "Least Issues") return b.openIssues - a.openIssues
+    else if (sortBy == "Recently Updated") return a.updatedAt - b.updatedAt
+    else return 0.5 - Math.random()
+})
+
 const repos = dbRepos.reduce<DisplayRepository[]>((acc, cur) => {
     if (cur.sponsor && sponsoredCount++ < 8) {
         return [cur, ...acc]
@@ -141,6 +160,14 @@ const user = Astro.locals.user;
                             <option value = {date.id} class = "text-black" selected = {selectedDate === date.id}>{date.display}</option>)}
                 </select>
             </div>
+            <div class = "flex gap-x-2">
+                <label for = "sort_by" class="flex-none">Sort By:</label>
+
+                <select id = "sort_by" name = "sort_by" class = "bg-transparent focus:bg-primary/10 outline outline-white/10 focus:outline-primary w-full sm:w-auto">
+                    {SORT_FILTERS.map(sort =>
+                            <option value = {sort} class = "text-black" selected = {sortBy === sort}>{sort}</option>)}
+                </select>
+            </div>
         </div>
         <div class = "flex flex-col sm:flex-row gap-8 flex-wrap mt-6 w-full justify-center">
             {repos.map((repo) =>
@@ -154,6 +181,7 @@ const user = Astro.locals.user;
     <script>
         const tags = document.getElementById("tags")!;
         const updatedWithin = document.getElementById("updated_within")!;
+        const sortBy = document.getElementById("sort_by")!;
         const url = new URL(window.location as unknown as string) ;
         tags.addEventListener("change", async (e) => {
             e.preventDefault();
@@ -175,6 +203,18 @@ const user = Astro.locals.user;
                 url.searchParams.set("updated_within", select.value);
             } else {
                 url.searchParams.delete("updated_within");
+            }
+            window.location = url as unknown as Location;
+        })
+
+        sortBy.addEventListener("change", async (e) => {
+            e.preventDefault();
+            const select = e.target as HTMLSelectElement
+
+            if (select.value) {
+                url.searchParams.set("sort_by", select.value);
+            } else {
+                url.searchParams.delete("sort_by");
             }
             window.location = url as unknown as Location;
         })

--- a/src/pages/repositories/index.astro
+++ b/src/pages/repositories/index.astro
@@ -133,11 +133,11 @@ const user = Astro.locals.user;
 ---
 <Layout title = "Repositories" description = "Repositories" canonical = "/repositories" currentPage = "repositories" wide = {true}>
     <div class = "mx-auto">
-        <h1 class:list = {["text-white text-3xl font-semibold font-brand border-b-2 tracking-wide mb-4 pb-4 font-brand", {"flex justify-between": user}]}>
-            <span>Repositories</span>
+        <h1 class:list = {["text-white text-3xl font-semibold border-b-2 tracking-wide mb-4 pb-4", {"flex justify-between": user}]}>
+            <span class = "font-brand">Repositories</span>
 
             {user && <a href = "/repositories/submit" class = "no-underline">
-                <button class = "px-4 border border-primary rounded-md text-lg font-bold shadow-sm bg-primary text-black animate-sm-glow hover:bg-secondary hover:border-secondary  transition-colors">Submit</button>
+                <button class = "px-4 border border-primary rounded-md text-lg font-bold shadow-sm bg-primary text-black animate-sm-glow hover:bg-secondary hover:border-secondary transition-colors">Submit</button>
             </a>}
         </h1>
         <div class = "flex flex-col sm:flex-row gap-4">

--- a/src/pages/repositories/index.astro
+++ b/src/pages/repositories/index.astro
@@ -11,6 +11,8 @@ const now = new Date();
 
 const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
 const DATE_FILTERS = [
+    {display: "7 Days", id: "7d", date: now.getTime() - MILLISECONDS_PER_DAY * 7},
+    {display: "30 Days", id: "30d", date: now.getTime() - MILLISECONDS_PER_DAY * 30},
     {display: "90 Days", id: "90d", date: now.getTime() - MILLISECONDS_PER_DAY * 90},
     {display: "180 Days", id: "180d", date: now.getTime() - MILLISECONDS_PER_DAY * 180},
     {display: "1 Year", id: "1y", date: now.getTime() - MILLISECONDS_PER_DAY * 365},
@@ -144,7 +146,7 @@ const user = Astro.locals.user;
                 <label for = "tags">Tags:</label>
 
                 <select id = "tags" name = "tags" class = "bg-transparent focus:bg-primary/10 outline outline-white/10 focus:outline-primary w-full sm:w-auto">
-                    <option label = ""></option>
+                    <option label = "All"></option>
                     {tags.map((tag) =>
                             <option value = {tag} class = "text-black" selected = {selectedTag === tag}>{tag}</option>
                     )}
@@ -155,7 +157,7 @@ const user = Astro.locals.user;
                 <label for = "updated_within" class="flex-none">Updated Within:</label>
 
                 <select id = "updated_within" name = "updated_within" class = "bg-transparent focus:bg-primary/10 outline outline-white/10 focus:outline-primary w-full sm:w-auto">
-                    <option label = ""></option>
+                    <option label = "Any"></option>
                     {DATE_FILTERS.map(date =>
                             <option value = {date.id} class = "text-black" selected = {selectedDate === date.id}>{date.display}</option>)}
                 </select>


### PR DESCRIPTION
This PR, on the Repositories page:
* Adds sorting to repositories, allowing the user to sort between:
  * Random (current, default)
  * Recently Updated - no opposite because I can't see a point
  * Most Stars
  * Least Stars
  * Most Issues
  * Least Issues
* Adds 7 & 30 day filters for the updated within filter
* Gives default values for the filters
* Makes only the actual heading be in the brand font & medium weight, not the submit button - hurt readability
  * This button is also still inconsistent with every other button, none have glow or this padding

You can see these changes below:

<img width="1096" height="247" alt="image" src="https://github.com/user-attachments/assets/6817b57f-e8c7-4e6f-b800-1ad865547a16" />

Let me know if there are any issues or if I should split this into multiple PRs - didn't see anything in [CONTRIBUTING.md](https://github.com/Mycelium-Mod-Network/Modtoberfest-Site/blob/main/CONTRIBUTING.md) about it.